### PR TITLE
Update admittance stiffness state in a separate loop

### DIFF
--- a/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp
+++ b/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp
@@ -331,13 +331,17 @@ void AdmittanceRule::process_wrench_measurements(
 
 const control_msgs::msg::AdmittanceControllerState & AdmittanceRule::get_controller_state()
 {
+  for (size_t i = 0; i < state_message_.stiffness.data.size(); ++i)
+  {
+    state_message_.stiffness.data[i] = admittance_state_.stiffness[i];
+  }
+
   for (size_t i = 0; i < parameters_.joints.size(); ++i)
   {
     state_message_.joint_state.name[i] = parameters_.joints[i];
     state_message_.joint_state.position[i] = admittance_state_.joint_pos[i];
     state_message_.joint_state.velocity[i] = admittance_state_.joint_vel[i];
     state_message_.joint_state.effort[i] = admittance_state_.joint_acc[i];
-    state_message_.stiffness.data[i] = admittance_state_.stiffness[i];
     state_message_.damping.data[i] = admittance_state_.damping[i];
     state_message_.selected_axes.data[i] = static_cast<bool>(admittance_state_.selected_axes[i]);
     state_message_.mass.data[i] = admittance_state_.mass[i];


### PR DESCRIPTION
Resolves https://github.com/PickNikRobotics/moveit_studio/issues/4053

If the number of robot joints is more than 6, the current setup will segfault with an out-of-bound access error. 
Here is a fix for it.
